### PR TITLE
Fix temperature display in ListBox

### DIFF
--- a/Model/Temperature.cs
+++ b/Model/Temperature.cs
@@ -21,7 +21,7 @@ namespace InterviewProblem.Model
 
         public double TempC => 5 / TcVolts + 35;
 
-        public double TempF => TempC;  // Fix conversion
+        public double TempF => TempC * 9 / 5 + 32;  // Fix conversion
 
         public bool WithinLimits
         {

--- a/View/TemperatureView.xaml
+++ b/View/TemperatureView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="InterviewProblem.View.TemperatureView"
+<UserControl x:Class="InterviewProblem.View.TemperatureView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -19,7 +19,7 @@
         <TextBlock Grid.Column="1" Margin="2" FontSize="12" Text="{Binding Temperature.TimeStamp}" HorizontalAlignment="Left"></TextBlock>
         <Border Grid.Column="2" Grid.RowSpan="2" BorderBrush="CadetBlue" BorderThickness="1"></Border>
         <TextBlock Grid.Column="3" Margin="4,2,2,2" FontSize="12" FontWeight="Bold">Temperature:</TextBlock>
-        <TextBlock Grid.Column="4" Margin="2" FontSize="12" Text="{Binding Temperature.TempFarenheit, StringFormat={}{0:F1}°F}" HorizontalAlignment="Left"></TextBlock>
+        <TextBlock Grid.Column="4" Margin="2" FontSize="12" Text="{Binding Temperature.TempF, StringFormat={}{0:F1}°F}" HorizontalAlignment="Left"></TextBlock>
         <Image Grid.Column="4" Margin="2" HorizontalAlignment="Right">
             <Image.Style>
                 <Style TargetType="Image">


### PR DESCRIPTION
Fix the bug where the temperature is not showing up in Fahrenheit in the ListBox.

* **Model/Temperature.cs**
  - Update the `TempF` property to correctly convert Celsius to Fahrenheit.

* **View/TemperatureView.xaml**
  - Update the `TextBlock` binding for temperature to use `Temperature.TempF` instead of `Temperature.TempFarenheit`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GrahamGaston/InterviewApplication/pull/2?shareId=f9c4394c-a00e-437a-96e5-54843b93a54f).